### PR TITLE
fix: Wordpress importer

### DIFF
--- a/app/templates/pdf/receipt.html
+++ b/app/templates/pdf/receipt.html
@@ -138,7 +138,7 @@ table; Stupid I know) - Use width style over class {% endcomment %}
                       style="padding: 2px 0px 0px 0px"
                       class="table-border b-1px fw-bold ta-c lh-11"
                     >
-                      {{ donor.customer_ref }}
+                      {{ donor.id }}
                     </td>
                   </tr>
                 </table>

--- a/app/worker/tasks/create_receipt.py
+++ b/app/worker/tasks/create_receipt.py
@@ -48,7 +48,7 @@ class Receiptor(LoggerTask):
             context = self.generate_context(donation)
 
             pdf = render_to_pdf('pdf/receipt.html', donation.pk, context)
-            file_name = f'Tax Receipt {donation.pk}.pdf'
+            file_name = f'{donation.pk} {donation.donor.donor_name}.pdf'
             self.pdfs.append(pdf)
             self.pdf_names.append(file_name)
             self.mails.append(

--- a/app/worker/tasks/importers/webform_data_importer.py
+++ b/app/worker/tasks/importers/webform_data_importer.py
@@ -60,7 +60,7 @@ class WebformDataImporter(BaseCsvImporter):
         certificate = row["Do you require a certificate of data erasure?"]
         certificate = "Yes" if certificate.lower() == "yes" else "No"
         received_by = row.get("1", None)
-        items = "\n".join(self._parse_items(row))
+        # items = "\n".join(self._parse_items(row))
 
         notes = ""
         if received_by:
@@ -71,7 +71,7 @@ class WebformDataImporter(BaseCsvImporter):
             notes += f"Require Certificate of Data Erasure?: {certificate}\n"
         if note:
             notes += f"Additional Notes: {note}\n"
-        notes += f"Items: {items}"
+        # notes += f"Items: {items}"
 
         return {
             "pledge_date": parse(row["Entry Date"]).date(),


### PR DESCRIPTION
- Remove adding items to webform importer
- Modify receipt export name to '2021-xxxx donor_name'
- Modified receipt donor.customer_ref to donor.id

Closes #305 