### PR TITLE
Add More Test Coverage

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,9 @@
+version: "2"
+
 checks:
   file-lines:
     config:
       threshold: 300
-
-languages:
-  Python: true
 
 plugins:
   pep8:
@@ -12,8 +11,7 @@ plugins:
   csslint:
     enabled: false
 
-exclude_paths:
+exclude_patterns:
   - "**/vendor/"
   - "**/migrations/"
-  - "/test"
   -  "app/constants/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,3 @@
-checks:
-  file-lines:
-    exclude_paths:
-      - "**/test_*.py"
 languages:
   Python: true
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,7 @@
+checks:
+  file-lines:
+    exclude_paths:
+      - "**/test_*.py"
 languages:
   Python: true
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,8 @@
+checks:
+  file-lines:
+    config:
+      threshold: 300
+
 languages:
   Python: true
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,7 @@
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "make codespace",
+  "postStartCommand": "make env",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "make codespace",
-  "postStartCommand": "make env",
+  "postStartCommand": "make env && make celery",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 ADMIN=NAME,email@host.ca
 ALLOWED_HOSTS=rebootcanadadb.herokuapp.com,rebootcanada.herokuapp.com,localhost,0.0.0.0,127.0.0.1
+CELERY_RESULT_BACKEND="rpc://"
 CLOUDAMQP_APIKEY=
 CLOUDAMQP_URL=
 CSRF_TRUSTED_ORIGINS=.preview.app.github.dev

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-      "source.organizeImports": true
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "ms-python.autopep8",
     "editor.formatOnSave": true

--- a/app/test_admin.py
+++ b/app/test_admin.py
@@ -101,6 +101,7 @@ class DonationAdminTestCase(TestCase):
                             device=item_device, quantity=1, working=True)
 
         admin_site = AdminSite()
+        admin_site.register(model_or_iterable=Donor)
         self.donation_admin = DonationAdmin(
             model=Donation, admin_site=admin_site)
 
@@ -269,6 +270,16 @@ class DonationAdminTestCase(TestCase):
         self.assertSequenceEqual(seq1=got_readonly_fields, seq2=(
             "donor_contact_name", "donor_donor_name", "donor_email",
             "donor_mobile_number", "status"))
+
+    def test_formfield_for_foreignkey(self) -> None:
+        request = self.request_factory.get(path="")
+
+        got_formfield = self.donation_admin.formfield_for_foreignkey(
+            db_field=Donation._meta.get_field(field_name="donor"), request=request, using=None)
+        got_widget_context = got_formfield.widget.get_context(name=None, value=None, attrs=None)
+        got_related_add_url = got_widget_context["related_add_url"]
+
+        self.assertEqual(first=got_related_add_url, second="/app/donor/add/?_to_field=id")
 
 
 class ItemAdminTestCase(TestCase):

--- a/app/test_admin.py
+++ b/app/test_admin.py
@@ -6,7 +6,7 @@ from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
 
-from app.admin import DonationAdmin, DonorAdmin, ItemAdmin
+from app.admin import DonationAdmin, DonorAdmin, ItemAdmin, ItemInline
 from app.enums.item_status_enum import ItemStatusEnum
 from app.models.donation import Donation
 from app.models.donor import Donor
@@ -61,6 +61,32 @@ class DonorAdminTestCase(TestCase):
             got_donor = None
 
         self.assertIsNone(obj=got_donor)
+
+
+class ItemInlineTestCase(TestCase):
+    def setUp(self) -> None:
+        admin_site = AdminSite()
+        self.item_inline = ItemInline(
+            parent_model=Donation, admin_site=admin_site)
+
+        self.request_factory = RequestFactory()
+
+        self.user = User.objects.create_user(
+            username="tester", email="tester@example.com", password="testing")
+
+        return super().setUp()
+
+    def test_get_readonly_fields(self) -> None:
+        want_readonly_fields = ("value", "valuation_date",
+                                "valuation_supporting_doc", "status")
+
+        request = self.request_factory.patch(path="")
+        request.user = self.user
+
+        got_readonly_fields = self.item_inline.get_readonly_fields(req=request)
+
+        self.assertTupleEqual(tuple1=got_readonly_fields,
+                              tuple2=want_readonly_fields)
 
 
 class DonationAdminTestCase(TestCase):

--- a/app/test_admin.py
+++ b/app/test_admin.py
@@ -281,6 +281,18 @@ class DonationAdminTestCase(TestCase):
 
         self.assertEqual(first=got_related_add_url, second="/app/donor/add/?_to_field=id")
 
+    def test_get_changelist_instance(self) -> None:
+        donations = Donation.objects.all()
+        donations_list = list(donations)
+        request = self.request_factory.get(path="")
+        request.user = self.user
+
+        got_changelist = self.donation_admin.get_changelist_instance(request=request)
+        got_queryset = got_changelist.get_queryset(request=request)
+        got_queryset_list = list(got_queryset)
+
+        self.assertEqual(first=got_queryset_list, second=donations_list)
+
 
 class ItemAdminTestCase(TestCase):
     def setUp(self) -> None:

--- a/app/test_admin.py
+++ b/app/test_admin.py
@@ -275,11 +275,14 @@ class DonationAdminTestCase(TestCase):
         request = self.request_factory.get(path="")
 
         got_formfield = self.donation_admin.formfield_for_foreignkey(
-            db_field=Donation._meta.get_field(field_name="donor"), request=request, using=None)
-        got_widget_context = got_formfield.widget.get_context(name=None, value=None, attrs=None)
+            db_field=Donation._meta.get_field(field_name="donor"),
+            request=request, using=None)
+        got_widget_context = got_formfield.widget.get_context(
+            name=None, value=None, attrs=None)
         got_related_add_url = got_widget_context["related_add_url"]
 
-        self.assertEqual(first=got_related_add_url, second="/app/donor/add/?_to_field=id")
+        self.assertEqual(first=got_related_add_url,
+                         second="/app/donor/add/?_to_field=id")
 
     def test_get_changelist_instance(self) -> None:
         donations = Donation.objects.all()
@@ -287,7 +290,8 @@ class DonationAdminTestCase(TestCase):
         request = self.request_factory.get(path="")
         request.user = self.user
 
-        got_changelist = self.donation_admin.get_changelist_instance(request=request)
+        got_changelist = self.donation_admin.get_changelist_instance(
+            request=request)
         got_queryset = got_changelist.get_queryset(request=request)
         got_queryset_list = list(got_queryset)
 

--- a/app/test_admin.py
+++ b/app/test_admin.py
@@ -282,3 +282,21 @@ class ItemAdminTestCase(TestCase):
         want_status = ItemStatusEnum.PLEDGED.value.upper()
         self.assertEqual(first=self.item.status,
                          second=want_status)
+
+    def test_destroy_item(self) -> None:
+        request = self.request_factory.delete(path="")
+        request.user = self.user
+        sessionMiddleware = SessionMiddleware()
+        sessionMiddleware.process_request(request=request)
+        messageMiddleware = MessageMiddleware()
+        messageMiddleware.process_request(request=request)
+        items = Item.objects.all()
+
+        self.item_admin.destroy_item(req=request, qs=items)
+
+        try:
+            got_item = Item.objects.get(donation=self.item.donation)
+        except Item.DoesNotExist:
+            got_item = None
+
+        self.assertIsNone(obj=got_item)

--- a/app/views/test_data_view.py
+++ b/app/views/test_data_view.py
@@ -34,6 +34,14 @@ class DataViewTestCase(TestCase):
         self.assertEqual(first=response.status_code, second=200)
         self.assertEqual(first=total_value, second=246.0)
 
+    def test_aggregate_status(self) -> None:
+        response = self.client.get(path="/api/status")
+        response_json = response.json()
+        count = response_json["result"][0]["count"]
+
+        self.assertEqual(first=response.status_code, second=200)
+        self.assertEqual(first=count, second=1)
+
     def test_aggregate_location(self) -> None:
         response = self.client.get(path="/api/location")
         response_json = response.json()

--- a/app/views/test_data_view.py
+++ b/app/views/test_data_view.py
@@ -11,24 +11,33 @@ from app.models.item_device import ItemDevice
 
 class DataViewTestCase(TestCase):
     def setUp(self) -> None:
-        self.client = Client()
-
-        user_password = "testing"
-        self.user = User.objects.create_superuser(
-            "tester", email="tester@example.com", password=user_password)
-        self.client.login(username=self.user.username, password=user_password)
-
-        return super().setUp()
-
-    def test_aggregate_value(self) -> None:
         donor = Donor.objects.create()
         donation = Donation.objects.create(donor=donor)
         item_device = ItemDevice.objects.create()
         Item.objects.create(donation=donation, device=item_device,
                             quantity=2, working=True, value=123)
 
+        user_password = "testing"
+        self.user = User.objects.create_superuser(
+            "tester", email="tester@example.com", password=user_password)
+
+        self.client = Client()
+        self.client.login(username=self.user.username, password=user_password)
+
+        return super().setUp()
+
+    def test_aggregate_value(self) -> None:
         response = self.client.get(path="/api/value")
         response_json = response.json()
+        total_value = response_json["result"][0]["total_value"]
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json["result"][0]["total_value"], 246.0)
+        self.assertEqual(first=response.status_code, second=200)
+        self.assertEqual(first=total_value, second=246.0)
+
+    def test_aggregate_location(self) -> None:
+        response = self.client.get(path="/api/location")
+        response_json = response.json()
+        count = response_json["result"][0]["count"]
+
+        self.assertEqual(first=response.status_code, second=200)
+        self.assertEqual(first=count, second=1)

--- a/app/views/test_views.py
+++ b/app/views/test_views.py
@@ -93,4 +93,6 @@ class ViewsTestCase(TestCase):
         response = download_file(request=request)
         content_type = response["Content-Type"]
 
-        self.assertEqual(first=content_type, second="application/zip")
+        self.assertEqual(first=content_type, second="application/zip", msg=(
+            "The content type of the receipt response was unexpected. "
+            "Is Celery running with a results backend enabled?"))

--- a/app/views/test_views.py
+++ b/app/views/test_views.py
@@ -3,7 +3,7 @@
 from django.contrib.auth.models import User
 from django.test import Client, RequestFactory, TestCase
 
-from app.views.views import download_receipt, export_csv
+from app.views.views import download_receipt, export_csv, import_csv
 
 
 class ViewsTestCase(TestCase):
@@ -18,6 +18,27 @@ class ViewsTestCase(TestCase):
         self.request_factory = RequestFactory()
 
         return super().setUp()
+
+    def test_import_csv_get(self) -> None:
+        request = self.request_factory.get(path="", data={"job": "test-job"})
+        request.user = self.user
+
+        response = import_csv(request=request)
+
+        self.assertContains(response=response,
+                            text="""<div class="progress">
+                                <div class="bar" role="progressbar"></div>
+                                </div>""",
+                            status_code=200, html=True)
+
+    def test_import_csv_post(self) -> None:
+        request = self.request_factory.post(path="")
+        request.user = self.user
+        request.queryset = {}
+
+        response = import_csv(request=request)
+
+        self.assertEqual(first=response.status_code, second=200)
 
     def test_export_csv_get(self) -> None:
         request = self.request_factory.get(path="", data={"job": "test-job"})

--- a/app/views/test_views.py
+++ b/app/views/test_views.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 
 from urllib.parse import parse_qs, urlparse
+
 from django.contrib.auth.models import User
 from django.test import Client, RequestFactory, TestCase
 
-from app.views.views import download_file, download_receipt, export_csv, import_csv
+from app.views.views import (
+    download_file,
+    download_receipt,
+    export_csv,
+    import_csv,
+)
 
 
 class ViewsTestCase(TestCase):

--- a/app/worker/tasks/exporter.py
+++ b/app/worker/tasks/exporter.py
@@ -1,9 +1,10 @@
 import csv
+
 from celery import task
 from celery.utils.log import get_task_logger
 from django.core import serializers
-from django.http import HttpResponse
 from django.db.models.query import QuerySet
+from django.http import HttpResponse
 
 from app.constants.field_names import CURRENT_FIELDS
 from app.worker.app_celery import AppTask, update_percent
@@ -42,7 +43,7 @@ class CsvExporter:
                 self.current_row += 1
                 self._log_status_if_pct_update()
 
-            self.logger.info("Import completed")
+            self.logger.info("Export completed")
             return output  # Celery will set SUCCESS on return
         except Exception:
             self.logger.error(f"Error on row #{self.current_row}")

--- a/app/worker/tasks/test_exporter.py
+++ b/app/worker/tasks/test_exporter.py
@@ -30,5 +30,7 @@ class ExporterTestCase(TestCase):
 
         response = exporter(file_name=file_name, qs=qs,
                             total_count=total_count)
+        content_type = response["Content-Type"]
 
         self.assertEqual(first=response.status_code, second=200)
+        self.assertEqual(first=content_type, second="application/csv")

--- a/app/worker/tasks/test_exporter.py
+++ b/app/worker/tasks/test_exporter.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from django.core.serializers import serialize
+from django.test import TestCase
+
+from app.models.donation import Donation
+from app.models.donor import Donor
+from app.models.item import Item
+from app.models.item_device import ItemDevice
+from app.worker.tasks.exporter import exporter
+
+
+class ExporterTestCase(TestCase):
+    def setUp(self) -> None:
+        donor = Donor.objects.create(
+            donor_name="Test", contact_name="Best", email="test@example.com",
+            mobile_number="+1 (234) 567-8901")
+        donation = Donation.objects.create(donor=donor)
+        item_device = ItemDevice.objects.create()
+        self.item = Item.objects.create(donation=donation,
+                                        device=item_device, quantity=1,
+                                        working=True)
+        return super().setUp()
+
+    def test_exporter(self) -> None:
+        file_name = "test_exporter.csv"
+        queryset = Item.objects.all()
+        qs = serialize(format="json", queryset=queryset)
+        total_count = len(queryset)
+
+        response = exporter(file_name=file_name, qs=qs,
+                            total_count=total_count)
+
+        self.assertEqual(first=response.status_code, second=200)

--- a/reboot/celeryconfig.py
+++ b/reboot/celeryconfig.py
@@ -10,8 +10,7 @@ event_queue_expires = 60
 worker_prefetch_multiplier = 1
 worker_concurrency = 10
 accept_content = ['json', 'pickle']
-result_backend = broker_url
-# result_backend = 'django-db'
+result_backend = config("CELERY_RESULT_BACKEND", default=broker_url)
 task_serializer = 'pickle'
 result_serializer = 'pickle'
 


### PR DESCRIPTION
This pull request expands test coverage yet again! It also ensures the development environment is started with the dev container to simplify getting started.

In order to unify the `download_receipt` tests, the Celery RPC results backend has to be enabled, so the Celery configuration is adjusted to enable overriding the backend.

The Code Climate configuration is also updated to use the latest syntax and increase the file lines threshold to 300.