### PR TITLE
Use Redis for Celery Result Backend

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,3 +4,4 @@ RUN apt-get update
 RUN	apt-get --yes install libcairo2-dev rabbitmq-server
 RUN	mkdir --parents /usr/local/var/postgres
 RUN chown vscode:vscode /usr/local/var/postgres
+RUN echo -e "\nvm.overcommit_memory = 1" >> /etc/sysctl.conf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,3 @@ RUN apt-get update
 RUN	apt-get --yes install libcairo2-dev rabbitmq-server
 RUN	mkdir --parents /usr/local/var/postgres
 RUN chown vscode:vscode /usr/local/var/postgres
-RUN echo -e "\nvm.overcommit_memory = 1" >> /etc/sysctl.conf

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,9 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers-contrib/features/postgres-asdf:1": {},
-    "ghcr.io/itsmechlark/features/redis-server:1": {}
+    "ghcr.io/itsmechlark/features/redis-server:1": {
+      "version": "7.0"
+    }
   },
 
   // Use portAttributes to map port numbers to default attributes.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,9 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
+    "ghcr.io/devcontainers-contrib/features/postgres-asdf:1": {
+      "version": "14.10"
+    },
     "ghcr.io/itsmechlark/features/redis-server:1": {
       "version": "7.0"
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers-contrib/features/postgres-asdf:1": {}
+    "ghcr.io/devcontainers-contrib/features/postgres-asdf:1": {},
+    "ghcr.io/itsmechlark/features/redis-server:1": {}
   },
 
   // Use portAttributes to map port numbers to default attributes.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
       "version": "14.10"
     },
     "ghcr.io/itsmechlark/features/redis-server:1": {
-      "version": "7.0"
+      "version": "7"
     }
   },
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 ADMIN=NAME,email@host.ca
 ALLOWED_HOSTS=rebootcanadadb.herokuapp.com,rebootcanada.herokuapp.com,localhost,0.0.0.0,127.0.0.1
-CELERY_RESULT_BACKEND="rpc://"
+CELERY_RESULT_BACKEND="redis://localhost:6379/0"
 CLOUDAMQP_APIKEY=
 CLOUDAMQP_URL=
 CSRF_TRUSTED_ORIGINS=.preview.app.github.dev

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,5 @@
 ADMIN=NAME,email@host.ca
 ALLOWED_HOSTS=rebootcanadadb.herokuapp.com,rebootcanada.herokuapp.com,localhost,0.0.0.0,127.0.0.1
-CELERY_RESULT_BACKEND="redis://localhost:6379/0"
 CLOUDAMQP_APIKEY=
 CLOUDAMQP_URL=
 CSRF_TRUSTED_ORIGINS=.preview.app.github.dev
@@ -14,6 +13,7 @@ EMAIL_HOST=smtp.gmail.com
 EMAIL_HOST_DISPLAY_NAME=
 EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
+REDIS_URL="redis://localhost:6379/0"
 # SECRET_KEY: Check out https://www.miniwebtool.com/django-secret-key-generator/ for generating new key
 SECRET_KEY=abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)
 SECURE_SSL_REDIRECT=False

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -77,7 +77,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       redis:
-        image: redis:7.0
+        image: redis:7
         ports:
           - 6379:6379
         options: --entrypoint redis-server --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -67,7 +67,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14.10
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -77,7 +77,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       redis:
-        image: redis
+        image: redis:7.0
         ports:
           - 6379:6379
         options: --entrypoint redis-server --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -52,7 +52,6 @@ jobs:
     env:
       ADMIN: NAME,email@host.ca
       ALLOWED_HOSTS: localhost,0.0.0.0,127.0.0.1
-      CELERY_RESULT_BACKEND: "rpc://"
       CSRF_TRUSTED_ORIGINS: ""
       DB_NAME: reboot
       DB_USER: root
@@ -62,6 +61,7 @@ jobs:
       EMAIL_HOST: smtp.gmail.com
       EMAIL_HOST_USER: ""
       EMAIL_HOST_PASSWORD: ""
+      REDIS_URL: "redis://localhost:6379/0"
       SECRET_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
       SECURE_SSL_REDIRECT: False
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -76,6 +76,12 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ migrate:
 
 .PHONY: celery
 celery:
-	celery worker -A reboot --without-gossip --without-heartbeat
+	celery worker -A reboot --without-heartbeat --without-gossip --without-mingle
 
 .PHONY: clean
 clean:

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-worker: celery worker -A reboot --without-gossip --without-heartbeat
+worker: celery worker -A reboot --without-heartbeat --without-gossip --without-mingle
 web: gunicorn reboot.wsgi --log-level info

--- a/app/worker/tasks/importers/test__init__.py
+++ b/app/worker/tasks/importers/test__init__.py
@@ -95,8 +95,7 @@ class InitTestCase(TestCase):
         })
         csvvalue = csvfile.getvalue().splitlines()
 
-        importers.historical_data_importer(
-            csvpath=csvvalue)
+        importers.historical_data_importer.apply(args=[csvvalue])
 
         got_donor = Donor.objects.get(donor_name="Example Danger Donor")
 

--- a/app/worker/tasks/test__init__.py
+++ b/app/worker/tasks/test__init__.py
@@ -20,8 +20,8 @@ class InitTestCase(TestCase):
         queryset_json = serializers.serialize(format="json", queryset=queryset)
         total_count = Donation.objects.count()
 
-        response = tasks.receiptor(
-            queryset=queryset_json, total_count=total_count)
+        result = tasks.receiptor.apply(args=[queryset_json, total_count])
+        response = result.get()
 
         self.assertEqual(first=response.status_code, second=200)
         self.assertEqual(
@@ -34,8 +34,8 @@ class InitTestCase(TestCase):
         queryset_json = serializers.serialize(format="json", queryset=queryset)
         total_count = Donation.objects.count()
 
-        response = tasks.receiptor(
-            queryset=queryset_json, total_count=total_count)
+        result = tasks.receiptor.apply(args=[queryset_json, total_count])
+        response = result.get()
 
         self.assertEqual(first=response.status_code, second=200)
         self.assertEqual(

--- a/app/worker/tasks/test_exporter.py
+++ b/app/worker/tasks/test_exporter.py
@@ -28,8 +28,8 @@ class ExporterTestCase(TestCase):
         qs = serialize(format="json", queryset=queryset)
         total_count = len(queryset)
 
-        response = exporter(file_name=file_name, qs=qs,
-                            total_count=total_count)
+        result = exporter.apply(args=[file_name, qs, total_count])
+        response = result.get()
         content_type = response["Content-Type"]
 
         self.assertEqual(first=response.status_code, second=200)

--- a/reboot/celeryconfig.py
+++ b/reboot/celeryconfig.py
@@ -10,7 +10,7 @@ event_queue_expires = 60
 worker_prefetch_multiplier = 1
 worker_concurrency = 10
 accept_content = ['json', 'pickle']
-result_backend = config("CELERY_RESULT_BACKEND")
+result_backend = config("REDIS_URL")
 task_serializer = 'pickle'
 result_serializer = 'pickle'
 

--- a/reboot/celeryconfig.py
+++ b/reboot/celeryconfig.py
@@ -1,6 +1,6 @@
 import ssl
-from decouple import config
 
+from decouple import config
 
 broker_url = config('CLOUDAMQP_URL', default='amqp://guest@localhost//')
 broker_connection_timeout = 30
@@ -10,7 +10,7 @@ event_queue_expires = 60
 worker_prefetch_multiplier = 1
 worker_concurrency = 10
 accept_content = ['json', 'pickle']
-result_backend = config("CELERY_RESULT_BACKEND", default=broker_url)
+result_backend = config("CELERY_RESULT_BACKEND")
 task_serializer = 'pickle'
 result_serializer = 'pickle'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Commented requirements indicate the latest patches of the earliest releases that support Python 3.9.
 
 # https://pypi.org/project/celery/5.1.2/
-# celery==5.1.2
-celery==4.4.7
+# celery[redis]==5.1.2
+celery[redis]==4.4.7
 # https://pypi.org/project/Django/2.2.28/
 Django==2.2.28
 # https://pypi.org/project/dj-database-url/1.0.0/


### PR DESCRIPTION
This pull request updates the Celery configuration to use Redis as the result backend.

In Heroku, we will need to set up a mini instance of [Heroku Data for Redis](https://elements.heroku.com/addons/heroku-redis). The environment variable `REDIS_URL` is used for [compatibility](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-python) with Heroku Data for Redis.

Tests for Celery task functions are updated to invoke the functions as tasks to ensure that task IDs are populated. Switching the result backend from RabbitMQ to Redis caused the absence of task IDs to be a breaking error for those tests. This seems like a good improvement 🤣  

This pull request also pins the version of PostgreSQL used in testing to match what is deployed in Heroku, and updates the Celery CLI commands to match [CloudAMQP recommendations](https://www.cloudamqp.com/docs/celery.html#commandline-arguments).